### PR TITLE
tick after setTime only if paused

### DIFF
--- a/src/timeline/timeline.js
+++ b/src/timeline/timeline.js
@@ -100,6 +100,7 @@ export default function timelineFactory(React, raf) {
     setTime(time) {
       this.time = (typeof time === 'function') ? time(this.time) : time;
       this.tween = (keyframes, easer) => tween(time, keyframes, easer);
+      !this.playing && this.tick();
     }
 
     play() { this.setPlay(true) }


### PR DESCRIPTION
It especially notable on demo 2 with the scrabble.
Without a tick in setTime the scrabble is useless when the timeline is paused
